### PR TITLE
Fix small bugs in mlho.it()

### DIFF
--- a/R/MSMR.lite.R
+++ b/R/MSMR.lite.R
@@ -24,22 +24,31 @@ MSMSR.lite <- function(MLHO.dat,
                        multicore=TRUE)
 {
 
-  require("plyr");require("DT")
+  # require("plyr");
+  require("dplyr")
+  require("DT")
 
   ## aggregating by unique patients
-  MLHO.dat.agg <- plyr::ddply(MLHO.dat, ~ phenx,summarise,distinct_patients=length(unique(patient_num)))
+  # MLHO.dat.agg <- plyr::ddply(MLHO.dat, ~ phenx,summarise,distinct_patients=length(unique(patient_num)))
+  MLHO.dat.table <- MLHO.dat %>% select(patient_num,phenx) %>% unique() %>% pull(phenx) %>% table()
+  MLHO.dat.agg <- data.frame(phenx=names(MLHO.dat.table),distinct_patients=as.vector(MLHO.dat.table)) # For JMI
   if(!is.na(sparsity)){
     print("step - 1: sparsity screening!")
     ##remove low-prevalence features
-    avrs <- c(as.character(subset(MLHO.dat.agg$phenx,MLHO.dat.agg$distinct_patients > round(length(patients)*sparsity))))
+    # avrs <- c(as.character(subset(MLHO.dat.agg$phenx,MLHO.dat.agg$distinct_patients > round(length(patients)*sparsity))))
+    avrs <- MLHO.dat.table[MLHO.dat.table > round(length(patients) * sparsity)] %>% names()
     MLHO.dat <- subset(MLHO.dat,MLHO.dat$phenx %in% avrs)
   }
   # setDT(MLHO.dat)
   # MLHO.dat[,row := .I]
   # MLHO.dat$value.var <- 1
 
-  MLHO.dat.wide <- reshape2::dcast(MLHO.dat, patient_num ~ phenx, value.var="value.var", fun.aggregate = length)
-  MLHO.dat.wide <- as.data.frame(MLHO.dat.wide)
+  # MLHO.dat.wide <- reshape2::dcast(MLHO.dat, patient_num ~ phenx, value.var="value.var", fun.aggregate = length)
+  # MLHO.dat.wide <- as.data.frame(MLHO.dat.wide)
+  MLHO.dat.wide <- MLHO.dat %>% 
+    dplyr::group_by(patient_num,phenx) %>% 
+    dplyr::summarise(n=n(),.groups = "drop") %>% 
+    tidyr::pivot_wider(id_cols = "patient_num",names_from = "phenx",values_from = n,values_fill = 0)
   MLHO.dat.wide <- MLHO.dat.wide[, !(names(MLHO.dat.wide) %in% c("NA"))]
 
   AVR <- MLHO.dat.wide
@@ -53,9 +62,10 @@ MSMSR.lite <- function(MLHO.dat,
       }
 
   print("step 2: JMI dimensionality reduction!")
-  AVR <- merge(AVR,labels,by="patient_num")
+  # AVR <- merge(AVR,labels,by="patient_num")
+  AVR <- dplyr::left_join(AVR,labels,by="patient_num")
   require("praznik")
-  AVR <- as.data.frame(AVR)
+  # AVR <- as.data.frame(AVR)
   ##calculating JOINT mutual information
   JMIs.AVR <- as.data.frame(JMI(AVR[,!(names(AVR) %in% names(labels))],
                                       as.factor(AVR$label),k = dim(AVR)[2]-ncol(labels), threads = 0)$score)
@@ -64,7 +74,8 @@ MSMSR.lite <- function(MLHO.dat,
   rownames(JMIs.AVR) <- NULL
   colnames(JMIs.AVR) <- c("JMI.score","phenx")
 
-  JMIs.AVR <- merge(JMIs.AVR,MLHO.dat.agg,by="phenx",all.x = TRUE)
+  # JMIs.AVR <- merge(JMIs.AVR,MLHO.dat.agg,by="phenx",all.x = TRUE)
+  JMIs.AVR <- dplyr::left_join(JMIs.AVR,MLHO.dat.agg,by="phenx")
   JMIs.AVR$JMI.score <- round(JMIs.AVR$JMI.score,3)
   JMIs.AVR$rank <- rank(order(order(JMIs.AVR$JMI.score,-JMIs.AVR$distinct_patients)))
 
@@ -76,13 +87,15 @@ MSMSR.lite <- function(MLHO.dat,
   }
 
   if (jmi==FALSE){
-    AVR <- merge(AVR,labels,by="patient_num")
+    # AVR <- merge(AVR,labels,by="patient_num")
+    AVR <- dplyr::left_join(AVR,labels,by="patient_num")
   }
 
   #binarize?
   if(binarize==TRUE){
     AVR[,2:dim(AVR)[2]] <- +(AVR[,2:dim(AVR)[2]] > 0)}
-
+  
+  AVR <- as.data.frame(AVR)
 
   return(AVR)
 

--- a/R/mlho.it.R
+++ b/R/mlho.it.R
@@ -55,10 +55,10 @@ mlho.it <- function(dbmart,
   test_ind <- sample(uniqpats,
                      round((test.sample/100)*length(uniqpats)))
 
-  test_labels <- subset(labeldt,labels$patient_num %in% c(test_ind))
+  test_labels <- subset(labels,labels$patient_num %in% c(test_ind))
   # print("test set lables:")
   table(test_labels$label)
-  train_labels <- subset(labeldt,!(labels$patient_num %in% c(test_ind)))
+  train_labels <- subset(labels,!(labels$patient_num %in% c(test_ind)))
   # print("train set lables:")
   table(train_labels$label)
   # train and test sets

--- a/R/mlho.it.R
+++ b/R/mlho.it.R
@@ -55,10 +55,10 @@ mlho.it <- function(dbmart,
   test_ind <- sample(uniqpats,
                      round((test.sample/100)*length(uniqpats)))
 
-  test_labels <- subset(labels,labels$patient_num %in% c(test_ind))
+  test_labels <- subset(labeldt,labels$patient_num %in% c(test_ind))
   # print("test set lables:")
   table(test_labels$label)
-  train_labels <- subset(labels,!(labels$patient_num %in% c(test_ind)))
+  train_labels <- subset(labeldt,!(labels$patient_num %in% c(test_ind)))
   # print("train set lables:")
   table(train_labels$label)
   # train and test sets

--- a/R/mlho.it.R
+++ b/R/mlho.it.R
@@ -110,6 +110,7 @@ mlho.it <- function(dbmart,
   },
   error = function(fr) {cat("ERROR :",conditionMessage(fr), "\n")})
     print(paste0("iteration ",i, " done!"))
+    closeAllConnections()
   }
   features <- do.call(rbind, lapply(feats, data.frame, stringsAsFactors=FALSE))
   features$X <- NULL


### PR DESCRIPTION
1) Changed `labeldt` to `labels` in `mlho.it()` to make it consistent with the function parameter, otherwise the function will use the global variable `labeldt`. 
2) Added `closeAllConnections()` at the end of `mlho.it()`. The original function always returns 'Error: all connections are in use' even though I am working on clusters, adding this line solves the problem.
2) Tried to accelerate MSMSR.lite() by modifying the data preparation part, but didn't accelerate much. You could ignore this part
